### PR TITLE
Update Step2 to indicate adding of username

### DIFF
--- a/basic-labs/ssh-to-remote-machine.md
+++ b/basic-labs/ssh-to-remote-machine.md
@@ -23,7 +23,7 @@ If you are Windows 10, MacOS, or Linux user, SSH will be available from the Comm
 1. Open SSH client window.
 2. Type the following command:
    ```
-   ssh computelabadmin@<ip-address-of-the-remote-machine>
+   ssh <username>@<ip-address-of-the-remote-machine>
    ```
 3. Enter the password for the remote machine.
 4. *Milestone step:* At this point, you have learned how to connect to a remote machine using SSH.


### PR DESCRIPTION
Addressed Issue #10 - The sample code given in step2 indicated where the user was to sub in the ip address of the remote machine, but there was no similar indication for the username. This change makes this more clear where the username is to be included, but using the same "`< >`" format indicated with the ip address placement.

Current version of the lab shows Step2 as follows:
![image](https://user-images.githubusercontent.com/49133101/135169848-3c470da6-95bc-4946-b38e-d26be1aa9f77.png)

Proposed change would be:

`ssh <username>@<ip-address-of-the-remote-machine>`
