### PR TITLE
creating-application-load-balancer-in-aws lab: Update Exercise 5 steps

### DIFF
--- a/networking-labs/aws/creating-application-load-balancer-in-aws.md
+++ b/networking-labs/aws/creating-application-load-balancer-in-aws.md
@@ -85,41 +85,44 @@ In this exercise, you will provision an Application Load Balancer in AWS.
 5. Click on the *Load Balancers*.
 6. Click on the ![Create Load Balancer button](media/aws-create-load-balancer-blue-button.png) button.
 7. Click on the ![Create button](media/aws-create-blue-button.png) button under *Application Load Balancer (HTTP/HTTPS)*.
-8. In *Step 1: Configure Load Balancer*, in the *Basic Configuration* section, fill in the following information:
+8. In the *Basic Configuration* section, fill in the following information:
   - *Name* → `[initials]-networkinglab-ec2-lb`
   - *Scheme* → `internet-facing`
   - *IP address type* → `ipv4`
-9. In *Step 1: Configure Load Balancer*, the *Availability Zones* section, select the following:
+9. In the *Network Mapping* section, select the following:
   - `us-west-2a`
   - `us-west-2b`
   - `us-west-2c`
   - `us-west-2d`
-10. In *Step 1: Configure Load Balancer*, expand the *Tags* section, and add the following tags:
+10. Expand the *Tags* section, and add the following tags:
   - *Name* → `[initials]-networkinglab-ec2-lb`
   - *Role* → `web`
   - *Lab* → `networkinglab`
   - *Owner* → `[your name]`
   - *OwnerEmail* → `[your email]`
-11. Click on the ![Next: Configure Security Settings button](media/aws-next-configure-security-settings-button.png) button.
-12. Click on the ![Next: Configure Security Groups button](media/aws-next-configure-security-groups-button.png) button.
-13. In *Step 3: Configure Security Groups*, change the radio button to `Create a new security group` and use the following values:
-  - *Security group name* → `[initials]-awsnetworkinglab-lb-sg`, where `[initials]` are your first, middle, and last name initials
-  - *Security group description* → `[your_full_name]'s security group for my load balancer on AWS`
-14. Click on the ![Next: Configure Routing button](media/aws-next-configure-routing-button.png) button.
-15. In *Step 4: Configure Routing*, in the *Target group* section, fill in the following:
-  - *Target group* → `New target group`
-  - *Name* → `[initials]-awsnetlab-web-instances`, where `[initials]` are your first, middle, and last name initials
-16. Leave the rest of the selections as by default.
-17. Click on the ![Next: Register Targets button](media/aws-next-register-targets-button.png) button.
-18. In *Step 5: Register Targets*, in the *Instances* section, select the following instances:
-  - `[initials]-awsnetworkinglab-instance01`
-  - `[initials]-awsnetworkinglab-instance02`
-  
-    where `[initials]` are your first, middle, and last name initials
-19. Click on the ![Add to registered button](media/aws-add-to-registered-blue-button.png) button.
-20. Click on the ![Next: Review button](media/aws-next-review-button.png) button.
-21. Click on the ![Create button](media/aws-create-button.png) button.
-22. Once the Application Load Balancer is deployed, click on the ![Close button](media/aws-close-button.png) button
+11. In the *Security Groups* section, select the `Create a new security group` link. In the new tab, use the following values:
+   - *Security group name* → `[initials]-awsnetworkinglab-lb-sg`, where `[initials]` are your first, middle, and last name initials
+   - *Security group description* → `[your_full_name]s security group for my load balancer on AWS`
+12. In the *Inbound Rules* section, select `Add Rule`.
+13. In the *Type* dropdown, select `HTTP`. In the *Source* dropdown, select `Anywhere-IPv4`.
+14. Click the orange `Create Security Group` button in the bottom right.
+15. Return to the Load Balancers tab. In the *Security Groups* section, click the refresh icon.
+16. In the *security groups* dropdown search for `[initials]-awsnetworkinglab-lb-sg` and select it.
+17. In the *Listeners and Routing* section, select the `Create Target Group` link. In the new tab, fill in the following:
+   - *Name* → `[initials]-awsnetlab-web-instances`, where `[initials]` are your first, middle, and last name initials
+18. Leave the rest of the selections as by default.
+19. Click on the orange `Next` button in the bottom right. 
+20. On the *Register Targets* page, select the following instances:
+   - `[initials]-awsnetworkinglab-instance01`
+   - `[initials]-awsnetworkinglab-instance02`
+   where `[initials]` are your first, middle, and last name initials.
+21. Click on the `Include As Pending Below` button.
+22. Click on the orange `Create Target Group` button in the bottom right.
+23. Return to the Load Balancers tab. In the *Listeners and Routing* section, click the refresh icon.
+24. In the *Default Action* dropdown, search for `[initials]-awsnetlab-web-instances`, where `[initials]` are your first, middle, and last name initials, and select it.
+25. Select the orange `Create Load Balancer` button in the bottom right.
+26. Once the Application Load Balancer is deployed, click on the `View Load Balancers` button.
+
 
 #### Exercise Summary
 At this point, you have learned how to provision an Application Load Balancer in AWS.


### PR DESCRIPTION
Resolves Issue #31.

This updates the [Creation Application Load Balancer in AWS](https://github.com/CrimsonPinnacle/cloud-labs/blob/main/networking-labs/aws/creating-application-load-balancer-in-aws.md) lab, Exercise 5 (Provision an Application Load Balancer in AWS) with the current steps needed to properly set up the Load Balancer in AWS.

Previous steps were outdated, and didn't accurately reflect the current process and navigation changes made to AWS's interface. Steps 8-22 have been replaced with Steps 8-26.